### PR TITLE
:bug: Fix credentials for pushing docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write # Allow to create a release.
+  packages: write # Allow pushing Docker images
 
 jobs:
   build:


### PR DESCRIPTION
Fix credentials for pushing docker images
```
docker push ghcr.io/kubeforce/cluster-api-kubeforce-controller-amd64:v0.0.1-alpha.1
The push refers to repository [ghcr.io/kubeforce/cluster-api-kubeforce-controller-amd64]
dcea02e50b69: Preparing
c456571abc85: Preparing
c456571abc85: Layer already exists
denied: installation not allowed to Write organization package
```